### PR TITLE
remove s3 attribute deprecation warning

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -9,7 +9,7 @@ resource "aws_cloudfront_distribution" "main" {
 
   origin {
     origin_id   = "origin-${var.fqdn}"
-    domain_name = aws_s3_bucket.main.website_endpoint
+    domain_name = aws_s3_bucket_website_configuration.main.website_endpoint
 
     # https://docs.aws.amazon.com/AmazonCloudFront/latest/
     # DeveloperGuide/distribution-web-values-specify.html


### PR DESCRIPTION
**dependencies**
1. Terraform v1.2.7
2. registry.terraform.io/hashicorp/aws v4.27.0

**steps**

`terraform init && terraform apply`


**observed**

```
│ Warning: Deprecated attribute
│
│   on .terraform/modules/github.redirect/cloudfront.tf line 12, in resource "aws_cloudfront_distribution" "main":
│   12:     domain_name = aws_s3_bucket.main.website_endpoint
│
│ The attribute "website_endpoint" is deprecated. Refer to the provider documentation for details.
│
│ (and one more similar warning elsewhere)
╵
```

**fix**

switch `aws_s3_bucket.website_endpoint` reference to `aws_s3_bucket_website_configuration.website_endpoint` in `cloudfront.tf`